### PR TITLE
minter: Use "patch asset" API instead of "export" for IPFS storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![LivepeerJS](https://user-images.githubusercontent.com/555740/117340053-78210e80-ae6e-11eb-892c-d98085fe6824.png)](https://livepeer.github.io/livepeerjs/)
 
 ---
+
 # Video NFT SDK
 
 [![npm](https://img.shields.io/npm/v/@livepeer/video-nft.svg?style=flat-square&color=green)](https://www.npmjs.com/package/@livepeer/video-nft)
-
 
 SDK for creating Video NFT minting applications.
 
@@ -26,11 +26,13 @@ Also provides a CLI for minting an NFT in 1-command.
 ### Package Managers
 
 #### yarn
+
 ```bash
 yarn add @livepeer/video-nft
 ```
 
 #### npm
+
 ```bash
 npm install @livepeer/video-nft
 ```
@@ -38,14 +40,14 @@ npm install @livepeer/video-nft
 Then the API can then be imported as a regular module:
 
 ```js
-import { videonft } from '@livepeer/video-nft'
+import { videonft } from '@livepeer/video-nft';
 
 // To upload videos from the filesystem
 const uploader = new videonft.minter.Uploader();
-// To process videos and export to IPFS
+// To manage videos in the API and store them in IPFS
 const vodApi = new videonft.minter.Api({ auth: { apiKey } });
 // To mint the NFT from the IPFS files
-const { chainId } = ethereum
+const { chainId } = ethereum;
 const web3 = new videonft.minter.Web3({ ethereum, chainId });
 ```
 
@@ -68,8 +70,9 @@ For more information about using the SDK check the [Usage](#usage) section.
 ## Getting Started
 
 Check our entry-point guides for getting started with this project:
-- [How to Mint a Video NFT](https://livepeer.com/docs/guides/video-nfts/mint-a-video-nft)
-- [Build a Video NFT app](https://livepeer.com/docs/guides/video-nfts/build-a-video-nft-app)
+
+ - [How to Mint a Video NFT](https://livepeer.com/docs/guides/video-nfts/mint-a-video-nft)
+ - [Build a Video NFT app](https://livepeer.com/docs/guides/video-nfts/build-a-video-nft-app)
 
 ## Documentation
 
@@ -118,11 +121,12 @@ contract](https://lvpr.link/create-erc721) guide.
 The main module is the
 [`videonft.minter`](https://livepeer.github.io/video-nft/modules/minter.html)
 which consists of 3 parts:
+
  - The `Uploader` to send files from the local context (e.g. picked by the user
    on a file picker) to the Livepeer API.
  - The `Api` component, used to interact with the Livepeer API or a proxy to it.
-   Abstracts the video-processing and IPFS exporting APIs for preparing the
-   video for an NFT.
+   Abstracts the video-processing and storing APIs for preparing the video for
+   an NFT.
  - The `Web3` component, used to actually mint the NFT given the IPFS URLs
    obtained from the `Api` component above.
 
@@ -169,7 +173,7 @@ The code below shows a simple example of how the whole flow would look like from
 the browser:
 
 ```js
-import { videonft } from '@livepeer/video-nft'
+import { videonft } from '@livepeer/video-nft';
 
 const apiOpts = {
   auth: { apiKey: 'your-api-key-here' },
@@ -209,7 +213,8 @@ async function mintNft() {
     description: 'My NFT description',
     traits: { 'my-custom-trait': 'my-custom-value' }
   };
-  const ipfs = await minter.api.exportToIPFS(asset.id, nftMetadata);
+  asset = await sdk.storeOnIPFS(asset.id, nftMetadata);
+  const ipfs = asset.storage?.ipfs?.status.addresses;
   const tx = await minter.web3.mintNft(ipfs.nftMetadataUrl);
   const nftInfo = await minter.web3.getMintedNftInfo(tx);
   console.log(`minted NFT on contract ${nftInfo.contractAddress} with ID ${nftInfo.tokenId}`);
@@ -243,11 +248,11 @@ import { createProxyMiddleware } from 'http-proxy-middleware';
 
 const app = express();
 const proxy = createProxyMiddleware({
-	target: 'https://livepeer.com',
-	changeOrigin: true,
-	headers: {
-		authorization: process.env.LP_API_KEY ?? ''
-	}
+  target: 'https://livepeer.com',
+  changeOrigin: true,
+  headers: {
+    authorization: process.env.LP_API_KEY ?? ''
+  }
 });
 
 app.get('/api/asset/:id', proxy);
@@ -255,6 +260,7 @@ app.get('/api/task/:id', proxy);
 app.post('/api/asset/request-upload', proxy);
 app.post('/api/asset/transcode', proxy);
 app.post('/api/asset/:id/export', proxy);
+app.patch('/api/asset/:id', proxy);
 
 app.listen(3000);
 ```
@@ -266,6 +272,7 @@ that) and changing the `endpoint` to where your backend is:
  - If your backend is running on the same domain as your frontend, you can
    actually omit the `endpoint` field as well and the client will default to the
    current origin:
+
 ```js
 const apiOpts = {};
 const minter = new videonft.minter.FullMinter(apiOpts, { ethereum, chainId });
@@ -275,6 +282,7 @@ const minter = new videonft.minter.FullMinter(apiOpts, { ethereum, chainId });
    the cross-origin request. You can use a package like
    [cors](https://www.npmjs.com/package/cors) for that. On the frontend, you
    only need to add the domain (with the scheme) to the `endpoint` field:
+
 ```js
 const apiOpts = { endpoint: 'https://backend.example.com' };
 const minter = new videonft.minter.FullMinter(apiOpts, { ethereum, chainId });

--- a/assets/video-nft.sol
+++ b/assets/video-nft.sol
@@ -12,7 +12,7 @@ import '@openzeppelin/contracts/utils/Counters.sol';
 
 interface IVideoNFT {
 	function mint(address owner, string memory tokenURI)
-		public
+		external
 		returns (uint256);
 
 	event Mint(
@@ -29,15 +29,9 @@ contract VideoNFT is ERC721URIStorage, IVideoNFT {
 
 	constructor() ERC721('Video NFT', 'VIDEO') {}
 
-	event Mint(
-		address indexed sender,
-		address indexed owner,
-		string tokenURI,
-		uint256 tokenId
-	);
-
 	function mint(address owner, string memory tokenURI)
 		public
+		override
 		returns (uint256)
 	{
 		require(

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance, AxiosRequestConfig, Method } from 'axios';
-import { Asset, Task, FfmpegProfile } from './types/schema';
+import { Asset, Task, FfmpegProfile, AssetPatchPayload } from './types/schema';
 
 export * from './types/schema';
 
@@ -267,17 +267,15 @@ export class VodApi {
 	}
 
 	/**
-	 * Requests for an asset to be exported from the Livepeer API to any external
-	 * location, most commonly to IPFS.
-	 *
-	 * @remarks
-	 * Refer to
-	 * {@link https://livepeer.com/docs/api-reference/vod/export | the API reference}
-	 * for more info.
+	 * Requests for an asset to be exported from the Studio service to any
+	 * external location not managed by Studio itself. This may be a custom URL
+	 * like a pre-signed one from to your own S3 bucket or credentials for your
+	 * own IPFS provider account, for which currently only Piñata is supported.
 	 *
 	 * @param id - the ID of the asset to be exported.
 	 * @param params - the export task parameters. Set `ipfs` field to export to
-	 * IPFS and the optional `nftMetadata` sub-field to customize the NFT metadata.
+	 * IPFS and the optional `nftMetadata` sub-field to customize the NFT
+	 * metadata.
 	 *
 	 * @returns the export `task` object that can be used to track progress and
 	 * wait for the output (check {@link getTask}).
@@ -288,6 +286,25 @@ export class VodApi {
 			`/api/asset/${id}/export`,
 			params
 		);
+	}
+
+	/**
+	 * Patches an asset definition. This can update only metadata of the asset
+	 * like the `name` or `meta` fields but it can also update the storage
+	 * configuration for a given asset. If you want to save the asset in custom
+	 * storages like IPFS, you can do so by setting the `storage` field
+	 * appropriately.
+	 *
+	 * @param id - the ID of the asset to be patched.
+	 * @param patch - the patch payload. Set the `ipfs` field to export to IPFS
+	 * and the optional `nftMetadata` field in its `spec` to customize the NFT
+	 * metadata.
+	 *
+	 * @returns the updated `asset` object. If you updated `storage`, check the
+	 * corresponding `status.tasks` to track progress (check {@link getTask}).
+	 */
+	patchAsset(id: string, patch: AssetPatchPayload) {
+		return this.makeRequest<Asset>('patch', `/api/asset/${id}`, patch);
 	}
 
 	private makeRequest = <T>(method: Method, url: string, data?: any) =>

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -20,14 +20,14 @@ async function videoNft() {
 
 	printStep('Starting export...');
 	asset = await sdk.storeOnIPFS(asset.id, args.nftMetadata, printProgress);
-	const ipfs = asset.storage?.ipfs?.status.addresses;
+	const ipfs = { ...asset.storage?.ipfs, spec: undefined };
 	console.log(
 		`Export successful! Result: \n${JSON.stringify(ipfs, null, 2)}`
 	);
 
 	printStep(
 		`Mint your NFT at:\n` +
-			`https://livepeer.com/mint-nft?tokenUri=${ipfs?.nftMetadataUrl}`
+			`https://livepeer.com/mint-nft?tokenUri=${ipfs?.nftMetadata?.url}`
 	);
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,11 +19,8 @@ async function videoNft() {
 	asset = await maybeTranscode(sdk, asset);
 
 	printStep('Starting export...');
-	let ipfs = await sdk.exportToIPFS(
-		asset.id,
-		args.nftMetadata,
-		printProgress
-	);
+	asset = await sdk.storeOnIPFS(asset.id, args.nftMetadata, printProgress);
+	const ipfs = asset.storage?.ipfs?.status.addresses;
 	console.log(
 		`Export successful! Result: \n${JSON.stringify(ipfs, null, 2)}`
 	);

--- a/src/minter.ts
+++ b/src/minter.ts
@@ -459,7 +459,7 @@ export class Api {
 				ipfs: { spec: { nftMetadata } }
 			}
 		});
-		const tasks = asset?.storage?.ipfs?.status?.tasks;
+		const tasks = asset?.storage?.status?.tasks;
 		await this.waitTask(tasks?.pending ?? '', reportProgress);
 		return await this.vod.getAsset(assetId);
 	}
@@ -745,13 +745,9 @@ export class FullMinter {
 			asset = await this.api.nftNormalize(asset);
 		}
 		asset = await this.api.storeOnIPFS(asset.id, args.nftMetadata);
-		const { nftMetadataUrl } = asset.storage?.ipfs?.status.addresses ?? {};
+		const nftMetadataUrl = asset.storage?.ipfs?.nftMetadata?.url ?? '';
 		const { contractAddress, to } = args?.mint ?? {};
-		const tx = await this.web3.mintNft(
-			nftMetadataUrl ?? '',
-			contractAddress,
-			to
-		);
+		const tx = await this.web3.mintNft(nftMetadataUrl, contractAddress, to);
 		return await this.web3.getMintedNftInfo(tx);
 	}
 }

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -29,19 +29,8 @@ export interface Asset {
 	objectStoreId?: string;
 	storage?: {
 		ipfs?: {
-			spec?: {
-				/**
-				 * Name of the NFT metadata template to export. 'player' will embed the Livepeer Player on the NFT while 'file' will reference only the immutable MP4 files.
-				 */
-				nftMetadataTemplate?: 'player' | 'file';
-				/**
-				 * Additional data to add to the NFT metadata exported to IPFS. Will be deep merged with the default metadata exported.
-				 */
-				nftMetadata?: {
-					[k: string]: unknown;
-				};
-			};
-			status?: {
+			spec: AssetIPFSSpec;
+			status: {
 				/**
 				 * Phase of the asset storage
 				 */
@@ -195,6 +184,19 @@ export interface Asset {
 	sourceAssetId?: string;
 }
 
+export interface AssetIPFSSpec {
+	/**
+	 * Name of the NFT metadata template to export. 'player' will embed the Livepeer Player on the NFT while 'file' will reference only the immutable MP4 files.
+	 */
+	nftMetadataTemplate?: 'player' | 'file';
+	/**
+	 * Additional data to add to the NFT metadata exported to IPFS. Will be deep merged with the default metadata exported.
+	 */
+	nftMetadata?: {
+		[k: string]: unknown;
+	};
+}
+
 export interface AssetIPFSAddresses {
 	/**
 	 * IPFS CID of the exported video file
@@ -220,6 +222,29 @@ export interface AssetIPFSAddresses {
 	 * URL to access metadata file via HTTP through an IPFS gateway
 	 */
 	nftMetadataGatewayUrl: string;
+}
+
+export interface AssetPatchPayload {
+	/**
+	 * Name of the asset. This is not necessarily the filename, can be a custom name or title
+	 */
+	name?: Asset['name'];
+	/**
+	 * User input metadata associated with the asset
+	 */
+	meta?: Asset['meta'];
+	/**
+	 * Storage configuration for an asset. This field will be merged with the one
+	 * provided in the patch, so you can just include new entries or override
+	 * specific ones.
+	 */
+	storage?: {
+		/**
+		 * Set to `true` to make a default export to IPFS. `false` or `null` means
+		 * to unpin from IPFS, but is unsupported right now.
+		 */
+		ipfs?: null | boolean | { spec?: null | AssetIPFSSpec };
+	};
 }
 
 export interface Task {
@@ -286,7 +311,7 @@ export interface Task {
 					};
 			  }
 			| {
-					ipfs: {
+					ipfs: AssetIPFSSpec & {
 						/**
 						 * Custom credentials for the Piñata service. Must have either a JWT or an API key and an API secret.
 						 */
@@ -307,12 +332,6 @@ export interface Task {
 									 */
 									apiSecret: string;
 							  };
-						/**
-						 * Additional data to add to the NFT metadata exported to IPFS. Will be deep merged with the default metadata exported.
-						 */
-						nftMetadata?: {
-							[k: string]: unknown;
-						};
 					};
 			  };
 		/**

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -28,35 +28,32 @@ export interface Asset {
 	 */
 	objectStoreId?: string;
 	storage?: {
-		ipfs?: {
-			spec: AssetIPFSSpec;
-			status: {
+		ipfs?: Partial<IpfsFileInfo> & {
+			spec?: AssetIPFSSpec;
+			nftMetadata?: IpfsFileInfo;
+		};
+		status?: {
+			/**
+			 * Phase of the asset storage
+			 */
+			phase: 'waiting' | 'ready' | 'failed' | 'reverted';
+			/**
+			 * Error message if the last storage changed failed.
+			 */
+			errorMessage?: string;
+			tasks: {
 				/**
-				 * Phase of the asset storage
+				 * ID of any currently running task that is exporting this asset to IPFS.
 				 */
-				phase: 'waiting' | 'ready' | 'failed' | 'reverted';
+				pending?: string;
 				/**
-				 * Error message if the last storage changed failed.
+				 * ID of the last task to run successfully, that created the currently saved data.
 				 */
-				errorMessage?: string;
-				tasks: {
-					/**
-					 * ID of any currently running task that is exporting this asset to IPFS.
-					 */
-					pending?: string;
-					/**
-					 * ID of the last task to run successfully, that created the currently saved data.
-					 */
-					last?: string;
-					/**
-					 * ID of the last task to fail execution.
-					 */
-					failed?: string;
-				};
+				last?: string;
 				/**
-				 * Addresses of the asset in IPFS from the last successful task execution.
+				 * ID of the last task to fail execution.
 				 */
-				addresses?: AssetIPFSAddresses;
+				failed?: string;
 			};
 		};
 	};
@@ -197,31 +194,19 @@ export interface AssetIPFSSpec {
 	};
 }
 
-export interface AssetIPFSAddresses {
+export interface IpfsFileInfo {
 	/**
-	 * IPFS CID of the exported video file
+	 * CID of the file on IPFS
 	 */
-	videoFileCid: string;
+	cid: string;
 	/**
-	 * URL for the file with the IPFS protocol
+	 * URL with IPFS scheme for the file
 	 */
-	videoFileUrl: string;
+	url?: string;
 	/**
 	 * URL to access file via HTTP through an IPFS gateway
 	 */
-	videoFileGatewayUrl: string;
-	/**
-	 * IPFS CID of the default metadata exported for the video
-	 */
-	nftMetadataCid: string;
-	/**
-	 * URL for the metadata file with the IPFS protocol
-	 */
-	nftMetadataUrl: string;
-	/**
-	 * URL to access metadata file via HTTP through an IPFS gateway
-	 */
-	nftMetadataGatewayUrl: string;
+	gatewayUrl?: string;
 }
 
 export interface AssetPatchPayload {
@@ -385,7 +370,32 @@ export interface Task {
 		 * Output of the export task
 		 */
 		export?: {
-			ipfs?: AssetIPFSAddresses;
+			ipfs?: {
+				/**
+				 * IPFS CID of the exported video file
+				 */
+				videoFileCid: string;
+				/**
+				 * URL for the file with the IPFS protocol
+				 */
+				videoFileUrl: string;
+				/**
+				 * URL to access file via HTTP through an IPFS gateway
+				 */
+				videoFileGatewayUrl: string;
+				/**
+				 * IPFS CID of the default metadata exported for the video
+				 */
+				nftMetadataCid: string;
+				/**
+				 * URL for the metadata file with the IPFS protocol
+				 */
+				nftMetadataUrl: string;
+				/**
+				 * URL to access metadata file via HTTP through an IPFS gateway
+				 */
+				nftMetadataGatewayUrl: string;
+			};
 		};
 		transcode?: {
 			asset?: {


### PR DESCRIPTION
We're changing the official way of storing an asset in IPFS. Instead of calling an "export" API,
users should now just patch the asset adding the desired storage locations. This makes more
sense since the On-demand Studio API is the one managing the IPFS storage, so it's not really
an export as it stays within Studio API control.

This does basically that, among with further updates to the schema from the latest changes.

Implements #9 